### PR TITLE
fix: add Windows support for Claude CLI detection and execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "claude-code-ai-commit-message-button",
-  "version": "1.0.0",
+  "name": "claude-commit",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-code-ai-commit-message-button",
-      "version": "1.0.0",
+      "name": "claude-commit",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",


### PR DESCRIPTION
- Skip bash/zsh shell detection on Windows platform
- Use PowerShell for base64 decoding on Windows
- Set appropriate shell (powershell.exe vs bash) based on platform
- Conditional PATH environment variable configuration
- Bump version to 1.0.1 and rename package to claude-commit