### PR TITLE
docs: add custom instructions configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,17 @@ That's it. No configuration, no setup wizards, no complexity.
 
 ## Extension Settings
 
-This extension keeps it simple with just two optional settings:
+This extension provides several optional settings to customize your experience:
 
-* `claude-commit.claudePath`: Custom path to Claude CLI executable (auto-detects by default)
-* `claude-commit.debugMode`: Enable debug output for troubleshooting
+- `claude-commit.claudePath`: Custom path to Claude CLI executable (auto-detects by default)
+- `claude-commit.debugMode`: Enable debug output for troubleshooting
+- `claude-commit.customInstructions`: Custom instructions for commit message generation
+- `claude-commit.instructionsFilePath`: Path to a file containing custom commit message instructions
 
 ## Configuration Examples
 
 ### Using a custom Claude path
+
 ```json
 {
     "claude-commit.claudePath": "/usr/local/bin/claude"
@@ -61,11 +64,46 @@ This extension keeps it simple with just two optional settings:
 ```
 
 ### Debug mode for troubleshooting
+
 ```json
 {
     "claude-commit.debugMode": true
 }
 ```
+
+### Custom instructions (inline)
+
+Provide custom rules directly in your settings:
+
+```json
+{
+    "claude-commit.customInstructions": "Summarize changes into a single sentence suitable for release notes. Focus on user-facing impact rather than technical details."
+}
+```
+
+### Custom instructions (from file)
+
+Use a file to share commit message conventions across your team:
+
+```json
+{
+    "claude-commit.instructionsFilePath": ".vscode/copilot/commit-message-instructions.md"
+}
+```
+
+Then create `.vscode/copilot/commit-message-instructions.md`:
+
+```markdown
+# Commit Message Instructions
+
+- Summarize changes into a sentence for release notes
+- Focus on the "why" rather than the "what"
+- Use imperative mood (e.g., "Add feature" not "Added feature")
+- Maximum 50 characters for the subject line
+- Include ticket number if applicable: [TICKET-123] Subject
+```
+
+The file path can be relative (from workspace root) or absolute. If both file and inline instructions are provided, the file takes precedence.
 
 ## Troubleshooting
 
@@ -96,6 +134,7 @@ If the extension can't find Claude CLI:
    - **Authentication**: Ensure Claude CLI is authenticated by running `claude setup-token` in terminal
 
 ### No commit message generated
+
 1. Ensure you have changes in your repository
 2. Check that Claude CLI is properly authenticated
 3. Enable debug mode to see the actual commands being executed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "claude-code-ai-commit-message-button",
-  "version": "1.0.0",
+  "name": "claude-commit",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-code-ai-commit-message-button",
-      "version": "1.0.0",
+      "name": "claude-commit",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,16 @@
           "type": "boolean",
           "default": false,
           "description": "Enable debug mode to show CLI commands being executed"
+        },
+        "claude-commit.customInstructions": {
+          "type": "string",
+          "default": "",
+          "description": "Custom instructions for commit message generation (e.g., 'Summarize changes into a sentence for release notes')"
+        },
+        "claude-commit.instructionsFilePath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to a file containing custom commit message instructions (e.g., '.vscode/copilot/commit-message-instructions.md')"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,9 @@
 import * as vscode from 'vscode';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 
 const execAsync = promisify(exec);
 
@@ -279,12 +282,37 @@ class ClaudeCLIExecutor {
             outputChannel.appendLine(`[EXECUTE] Using path: ${this.claudePath}`);
         }
 
-        // Use base64 encoding to completely avoid shell escaping issues
-        const base64Prompt = Buffer.from(prompt, 'utf8').toString('base64');
-        
-        // Build command that decodes base64 and pipes to claude
-        let command = `echo "${base64Prompt}" | base64 -d | ${this.claudePath}`;
-        
+        // For large prompts, use a temp file to avoid command-line length limits
+        // This affects all platforms when diffs are very large
+        let command;
+        let tempFile: string | null = null;
+        const maxInlineLength = 100000; // Conservative limit for command-line arguments
+
+        if (prompt.length > maxInlineLength) {
+            if (this.debugMode) {
+                outputChannel.appendLine(`[EXECUTE] Prompt too long (${prompt.length} chars), using temp file`);
+            }
+
+            // Create temp file with the prompt
+            tempFile = path.join(os.tmpdir(), `claude-prompt-${Date.now()}.txt`);
+            fs.writeFileSync(tempFile, prompt, 'utf8');
+
+            // Read from temp file and pipe to claude
+            command = `cat '${tempFile}' | ${this.claudePath}`;
+
+            if (this.debugMode) {
+                outputChannel.appendLine(`[EXECUTE] Temp file: ${tempFile}`);
+            }
+        } else {
+            // For shorter prompts, use base64 encoding inline
+            const base64Prompt = Buffer.from(prompt, 'utf8').toString('base64');
+            command = `echo "${base64Prompt}" | base64 -d | ${this.claudePath}`;
+
+            if (this.debugMode) {
+                outputChannel.appendLine(`[EXECUTE] Using inline base64 (${base64Prompt.length} chars)`);
+            }
+        }
+
         // Add all flags
         command += ' --print';  // Use explicit --print flag
         command += ' --model sonnet';  // Hardcoded model
@@ -292,8 +320,7 @@ class ClaudeCLIExecutor {
         command += ' --dangerously-skip-permissions';  // Skip permissions check
 
         if (this.debugMode) {
-            outputChannel.appendLine(`\n[EXECUTE] Command structure: echo [base64] | base64 -d | claude [options]`);
-            outputChannel.appendLine(`[EXECUTE] Base64 length: ${base64Prompt.length} chars`);
+            outputChannel.appendLine(`\n[EXECUTE] Command structure: ${tempFile ? 'temp file' : 'inline base64'} | claude [options]`);
             outputChannel.appendLine(`[EXECUTE] Original prompt length: ${prompt.length} chars`);
         }
         
@@ -381,11 +408,25 @@ class ClaudeCLIExecutor {
                 outputChannel.appendLine(`[EXECUTE] Error code: ${error.code}`);
                 outputChannel.appendLine(`[EXECUTE] Error stack: ${error.stack}`);
             }
-            
+
             if (error.code === 'ETIMEDOUT') {
                 throw new Error('Claude CLI timed out after 60 seconds. Please check if Claude is authenticated.');
             }
             throw new Error(`Claude CLI execution failed: ${error.message}`);
+        } finally {
+            // Clean up temp file if it was created
+            if (tempFile) {
+                try {
+                    fs.unlinkSync(tempFile);
+                    if (this.debugMode) {
+                        outputChannel.appendLine(`[EXECUTE] Cleaned up temp file: ${tempFile}`);
+                    }
+                } catch (cleanupError: any) {
+                    if (this.debugMode) {
+                        outputChannel.appendLine(`[EXECUTE] Warning: Failed to clean up temp file: ${cleanupError.message}`);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Extends extension settings to support custom commit message instructions via inline text or external file. Updates README with configuration examples and usage guidance.